### PR TITLE
add python version in the analysis_info.json of currentscape

### DIFF
--- a/Cellular/single_cell_currentscape_analysis/analysis_info.json
+++ b/Cellular/single_cell_currentscape_analysis/analysis_info.json
@@ -8,6 +8,7 @@
             "class": "list"
         }
     ],
+    "requires-python": ">=3.9,<3.13",
     "requirements": [
         "bluecellulab>=2.6.39",
         "matplotlib>=3.7.1",


### PR DESCRIPTION
add python version in the analysis_info.json of currentscape
Python version has to be lower than 3.13 because Neuron is not released yet on PyPi for this python version