### PR TITLE
Update folder names and Links for Platform

### DIFF
--- a/Cellular/emodels/plot_iv_fi_curve/README.md
+++ b/Cellular/emodels/plot_iv_fi_curve/README.md
@@ -1,4 +1,4 @@
-# IV/FI Curve Analysis
+# Plot IV/FI Curve
 Copyright (c) 2025 Open Brain Institute
 
 Authors: Ilkan Kilic and Darshan Mandge

--- a/Cellular/emodels/plot_iv_fi_curve/analysis_info.json
+++ b/Cellular/emodels/plot_iv_fi_curve/analysis_info.json
@@ -1,5 +1,5 @@
 {
-    "name": "IV/FI Curve Analysis",
+    "name": "Plot IV/FI Curve",
     "authors": ["OBI", "Ilkan Kiliç", "Darshan Mandge", "Aurélien Jaquier"],
     "description": "This notebook demonstrates how to compute and visualize IV and FI curves for a single-cell model using BlueCelluLab. It explores key neuronal properties like input resistance and firing threshold while showing how different injection and recording locations affect excitability and signal propagation.",
     "scale": "cellular",

--- a/Cellular/emodels/plot_iv_fi_curve/analysis_notebook.ipynb
+++ b/Cellular/emodels/plot_iv_fi_curve/analysis_notebook.ipynb
@@ -5,7 +5,7 @@
    "id": "5ae32a50",
    "metadata": {},
    "source": [
-    "# IV/FI Curve Analysis\n",
+    "# Plot IV/FI Curve\n",
     "\n",
     "Copyright (c) 2025 Open Brain Institute\n",
     "\n",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The folder has been divided into 3 main subfolders, each corresponding to the le
   - **emodels**: Notebooks on E-models. See this [README](Cellular/emodels/README.md) for more details
       - [**parameter_plots**](Cellular/emodels/parameters_plot/analysis_notebook.ipynb): Compare parameters of an e-model across sections on Open Brain Institute Platform (OBP)
       - [**cadpyr_showcase**](Cellular/emodels/cadpyr_showcase/analysis_notebook.ipynb): Demonstrates various properties of the OBP canonical cADPyr (continuos firing and adapting type pyramidal neuron) e-model
-      - [**iv_fi_curve**](Cellular/emodels/iv_fi_curve/analysis_notebook.ipynb): Computes and visualize IV and FI curves for a single-cell model using BlueCelluLab.
+      - [**plot_iv_fi_curve**](Cellular/emodels/plot_iv_fi_curve/analysis_notebook.ipynb): Computes and visualize IV and FI curves for a single-cell model using BlueCelluLab.
       - [**single_cell_currentscape_analysis**](Cellular/emodels/single_cell_currentscape_analysis/analysis_notebook.ipynb): Currentscape analysis of single cells
       - [**single_cell_impedance_analysis**](Cellular/emodels/single_cell_impedance_analysis/analysis_notebook.ipynb): Impedance analysis of single cells
       - **lfpy_simulations**


### PR DESCRIPTION
- Reverting to old iv/fi folder name for the platform. It was changed in this [PR](https://github.com/openbraininstitute/obi_platform_analysis_notebooks/pull/51/files). 

@g-bar @ayimaok Will this solve the issue in platform display of notebooks under `Projects > Notebooks > Member Notebooks`?