### PR TITLE
Add explicit insufficient funds message for neuron skeletonization

### DIFF
--- a/Cellular/skeletonization/analysis_notebook.ipynb
+++ b/Cellular/skeletonization/analysis_notebook.ipynb
@@ -39,6 +39,7 @@
     "import time \n",
     "import json \n",
     "import pathlib\n",
+    "import ipywidgets as w\n",
     "from uuid import UUID\n",
     "from urllib.parse import urlparse\n",
     "from IPython.display import display, HTML\n",
@@ -256,8 +257,12 @@
     "    output_morphology_id = UUID(job.get('output').get('morphology').get('id'))\n",
     "    break\n",
     "  elif status == 'failed':\n",
-    "    print(json.dumps(job, indent=2))\n",
-    "    raise RuntimeError(\"Skeletonization failed\")\n",
+    "    if ('ACCOUNTING_INSUFFICIENT_FUNDS_ERROR' in job.get('error', '')):\n",
+    "      display(w.HTML(\"<div style='color:#F5222D'><h3>Insufficient funds.</h3>Please add more credits to skeletonise this neuron.</div>\"))\n",
+    "      raise RuntimeError(\"Insufficient funds\")\n",
+    "    else:\n",
+    "      print(json.dumps(job, indent=2))\n",
+    "      raise RuntimeError(\"Skeletonization failed\")\n",
     "\n",
     "  time.sleep(15)"
    ]


### PR DESCRIPTION
Now, in case of insufficient funds the user will see a widget with an explicit message:

<img width="438" height="169" alt="Screenshot 2025-12-04 at 11 42 08" src="https://github.com/user-attachments/assets/81b3f406-0b90-4646-9c81-d4b0fbc526d4" />


Relates to [Insufficient credits error](https://github.com/openbraininstitute/Ultraliser/issues/152).